### PR TITLE
API endpoint changed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function SteamStatus(options) {
 
 SteamStatus.prototype.getServerStatuses = function(callback) {
 	var options = {
-		url: 'https://crowbar.steamdb.info/Barney',
+		url: 'https://crowbar.steamstat.us/Barney',
 		headers: {
 			'User-Agent': 'request',
 		}


### PR DESCRIPTION
Hello,
I just noticed, steamstat.us has changed their API endpoint to **https://crowbar.steamstat.us/Barney**.

Thanks for great plugin,
Cheers